### PR TITLE
use es modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "author": "",
   "license": "ISC",
   "description": "",
+  "type": "module",
   "dependencies": {
     "@cartesia/cartesia-js": "^1.2.2-alpha.0"
   },


### PR DESCRIPTION
Hi Gleb! Unless you specifically wanted to use CommonJS and not ES Modules, you probably just need to add `"type": "module"` to your `package.json`. Let me know if this fix works for you in your real project.

(If you actually want to use CommonJS, let me know — we don't make a CJS build right now but if you need it I can probably work it in)